### PR TITLE
Wm compositional comparison

### DIFF
--- a/wm_compositional/wm_grounding_comparison.py
+++ b/wm_compositional/wm_grounding_comparison.py
@@ -55,22 +55,19 @@ def obj_from_evidence(evidence) -> str:
 
 def get_entity_text(event):
     """Returns the text of the entity (subject or object)."""
-    db_refs = event.to_json()["concept"]["db_refs"]
-    entity_text = db_refs["TEXT"]
+    entity_text = event.concept.db_refs["TEXT"]
     return entity_text
 
 
 def get_groundings(event):
     """Returns a list of (grounding, confidence) tuples from an event."""
-    db_refs = event.to_json()["concept"]["db_refs"]
-    groundings = db_refs["WM"]
+    groundings = event.concept.db_refs["WM"]
     return groundings
 
 
 def get_compositional_groundings(event):
     """Returns a list of (grounding, confidence) tuples from an event."""
-    db_refs = event.to_json()["concept"]["db_refs"]
-    grounding = db_refs["WM"][0]
+    grounding = event.concept.db_refs["WM"][0]
     terms = []
     scores = []
     for item in grounding:
@@ -92,15 +89,31 @@ def get_CAG_nodes(statements):
     """
     nodes = []
     for statement in statements:
-        subj = statement.subj.to_json()["concept"]["db_refs"]["TEXT"]
-        obj = statement.obj.to_json()["concept"]["db_refs"]["TEXT"]
+        subj = statement.subj.concept.db_refs["TEXT"]
+        obj = statement.obj.concept.db_refs["TEXT"]
         if subj not in nodes:
             nodes.append(subj)
         if obj not in nodes:
             nodes.append(obj)
-    print(len(nodes))
+    print(f"{len(nodes)} unique nodes in the CAG.")
     return nodes
 
 
+def get_self_loops(statements):
+    """Gets list/number of nodes that point to themselves in the CAG.
+
+    Finds nodes where the subject and object top GROUNDING is the same.
+    """
+    self_loops = []
+    for statement in statements:
+        subj = statement.subj.concept.db_refs["WM"][0]
+        obj = statement.obj.concept.db_refs["WM"][0]
+        if subj == obj:
+            self_loops.append(statement)
+    print(f"{len(self_loops)} self-loops out of {len(statements)} statements.")
+
+
+
 get_CAG_nodes(stmts_flat)
+get_self_loops(stmts_flat)
 #make_comparison_sheet(stmts_flat)

--- a/wm_compositional/wm_grounding_comparison.py
+++ b/wm_compositional/wm_grounding_comparison.py
@@ -5,24 +5,40 @@ comparing the flat and compositional grounders.
 import csv
 from indra.statements import stmts_from_json_file
 
-stmts = stmts_from_json_file('statements.json', format='jsonl')
+# INDRA statements from flat ontology
+stmts_flat = stmts_from_json_file('statements.json', format='jsonl')
 
-def make_comparison_sheet(statements: list):
-    header = ["id", "Evidence", "Subject Text", "Subject Groundings", "Object Text", "Object Groundings"]
+# does not exist yet!
+stmts_comp = stmts_from_json_file('statements_comp.json', format='jsonl')
+
+def make_comparison_sheet(flat_statements, comp_statements):
+    header = ["Entity Text", "Grounding", "Confidence"]
     with open('wm_comparison_sheet.tsv', 'wt') as out_file:
         tsv_writer = csv.writer(out_file, delimiter='\t')
         tsv_writer.writerow(header)
-        i = 1
-        for statement in statements:
-            belief = statement.belief
-            evidences = statement.evidence
-            for evidence in evidences:
-                evidence_text = evidence.text
-                subject_text = subj_from_evidence(evidence)
-                object_text = obj_from_evidence(evidence)
-                line = [i, evidence_text, subject_text, groundings_from_event(statement.subj), object_text, groundings_from_event(statement.obj)]
-                tsv_writer.writerow(line)
-                i += 1
+        for statement in flat_statements[:500]:
+            # get text/groundings for flat subject/object
+            flat_subj_text = get_entity_text(statement.subj)
+            flat_subj_grounding = get_groundings(statement.subj)[0]
+            flat_obj_text = get_entity_text(statement.obj)
+            flat_obj_grounding = get_groundings(statement.obj)[0]
+            for statement in comp_statements[:500]:
+                # get text/groundings for compositional subject/object
+                # TODO: get into compositional tuples!
+                comp_subj_text = get_entity_text(statement.subj)
+                (comp_subj_groundings, comp_subj_scores) = get_compositional_groundings(statement.subj)
+                comp_obj_text = get_entity_text(statement.obj)
+                (comp_obj_groundings, comp_obj_scores) = get_compositional_groundings(statement.obj)
+
+                if (flat_subj_text == comp_subj_text && flat_obj_text == comp_obj_text):
+                    flat_subj_line = [flat_subj_text, flat_subj_grounding[0], flat_subj_grounding[1]]
+                    comp_subj_line = [comp_subj_text, comp_subj_groundings, comp_subj_scores]
+                    flat_obj_line = [flat_obj_text, flat_obj_grounding[0], flat_obj_grounding[1]]
+                    comp_obj_line = [comp_obj_text, comp_obj_groundings, comp_obj_scores]
+                    tsv_writer.writerow(flat_subj_line)
+                    tsv_writer.writerow(comp_subj_line)
+                    tsv_writer.writerow(flat_obj_line)
+                    tsv_writer.writerow(comp_obj_line)
 
 
 def subj_from_evidence(evidence) -> str:
@@ -44,10 +60,26 @@ def get_entity_text(event):
     return entity_text
 
 
-def groundings_from_event(event):
+def get_groundings(event):
     """Returns a list of (grounding, confidence) tuples from an event."""
     db_refs = event.to_json()["concept"]["db_refs"]
     groundings = db_refs["WM"]
     return groundings
 
-make_comparison_sheet(stmts)
+
+def get_compositional_groundings(event):
+    """Returns a list of (grounding, confidence) tuples from an event."""
+    db_refs = event.to_json()["concept"]["db_refs"]
+    grounding = db_refs["WM"][0]
+    terms = []
+    scores = []
+    for item in grounding:
+        if item != None:
+            term = item[0]
+            score = item[1]
+            terms.append(term)
+            scores.append(score)
+    return (terms, scores)
+
+
+make_comparison_sheet(stmts_flat)

--- a/wm_compositional/wm_grounding_comparison.py
+++ b/wm_compositional/wm_grounding_comparison.py
@@ -9,7 +9,7 @@ from indra.statements import stmts_from_json_file
 stmts_flat = stmts_from_json_file('statements.json', format='jsonl')
 
 # does not exist yet!
-stmts_comp = stmts_from_json_file('statements_comp.json', format='jsonl')
+#stmts_comp = stmts_from_json_file('statements_comp.json', format='jsonl')
 
 def make_comparison_sheet(flat_statements, comp_statements):
     header = ["Entity Text", "Grounding", "Confidence"]
@@ -30,7 +30,7 @@ def make_comparison_sheet(flat_statements, comp_statements):
                 comp_obj_text = get_entity_text(statement.obj)
                 (comp_obj_groundings, comp_obj_scores) = get_compositional_groundings(statement.obj)
 
-                if (flat_subj_text == comp_subj_text && flat_obj_text == comp_obj_text):
+                if (flat_subj_text == comp_subj_text & flat_obj_text == comp_obj_text):
                     flat_subj_line = [flat_subj_text, flat_subj_grounding[0], flat_subj_grounding[1]]
                     comp_subj_line = [comp_subj_text, comp_subj_groundings, comp_subj_scores]
                     flat_obj_line = [flat_obj_text, flat_obj_grounding[0], flat_obj_grounding[1]]
@@ -82,4 +82,25 @@ def get_compositional_groundings(event):
     return (terms, scores)
 
 
-make_comparison_sheet(stmts_flat)
+def get_CAG_nodes(statements):
+    """Returns number of nodes in CAG.
+
+    Loops through list of statements, counts unique subject/object nodes. Does
+    not distinguish if a node is the subject or object! Only counts it once.
+    Uses the node TEXT to match, not just the subj/obj, since those can show
+    the same Event but be unequal.
+    """
+    nodes = []
+    for statement in statements:
+        subj = statement.subj.to_json()["concept"]["db_refs"]["TEXT"]
+        obj = statement.obj.to_json()["concept"]["db_refs"]["TEXT"]
+        if subj not in nodes:
+            nodes.append(subj)
+        if obj not in nodes:
+            nodes.append(obj)
+    print(len(nodes))
+    return nodes
+
+
+get_CAG_nodes(stmts_flat)
+#make_comparison_sheet(stmts_flat)

--- a/wm_compositional/wm_grounding_comparison.py
+++ b/wm_compositional/wm_grounding_comparison.py
@@ -1,0 +1,53 @@
+"""
+Methods to poke around at INDRA statements and generate a sheet for 
+comparing the flat and compositional grounders.
+"""
+import csv
+from indra.statements import stmts_from_json_file
+
+stmts = stmts_from_json_file('statements.json', format='jsonl')
+
+def make_comparison_sheet(statements: list):
+    header = ["id", "Evidence", "Subject Text", "Subject Groundings", "Object Text", "Object Groundings"]
+    with open('wm_comparison_sheet.tsv', 'wt') as out_file:
+        tsv_writer = csv.writer(out_file, delimiter='\t')
+        tsv_writer.writerow(header)
+        i = 1
+        for statement in statements:
+            belief = statement.belief
+            evidences = statement.evidence
+            for evidence in evidences:
+                evidence_text = evidence.text
+                subject_text = subj_from_evidence(evidence)
+                object_text = obj_from_evidence(evidence)
+                line = [i, evidence_text, subject_text, groundings_from_event(statement.subj), object_text, groundings_from_event(statement.obj)]
+                tsv_writer.writerow(line)
+                i += 1
+
+
+def subj_from_evidence(evidence) -> str:
+    """Returns text of subject for a single piece of evidence."""
+    subject_text = evidence.annotations["agents"]["raw_text"][0]
+    return subject_text
+
+
+def obj_from_evidence(evidence) -> str:
+    """Returns text of object for a single piece of evidence."""
+    object_text = evidence.annotations["agents"]["raw_text"][1]
+    return object_text
+
+
+def get_entity_text(event):
+    """Returns the text of the entity (subject or object)."""
+    db_refs = event.to_json()["concept"]["db_refs"]
+    entity_text = db_refs["TEXT"]
+    return entity_text
+
+
+def groundings_from_event(event):
+    """Returns a list of (grounding, confidence) tuples from an event."""
+    db_refs = event.to_json()["concept"]["db_refs"]
+    groundings = db_refs["WM"]
+    return groundings
+
+make_comparison_sheet(stmts)

--- a/wm_compositional/wm_grounding_comparison.py
+++ b/wm_compositional/wm_grounding_comparison.py
@@ -1,36 +1,40 @@
 """
-Methods to poke around at INDRA statements and generate a sheet for 
+Methods to poke around at INDRA statements and generate a sheet for
 comparing the flat and compositional grounders.
 """
 import csv
 from indra.statements import stmts_from_json_file
+from tqdm import tqdm
 
 # INDRA statements from flat ontology
-stmts_flat = stmts_from_json_file('statements.json', format='jsonl')
+STMTS_FLAT = stmts_from_json_file('statements.json', format='jsonl')
 
 # does not exist yet!
 #stmts_comp = stmts_from_json_file('statements_comp.json', format='jsonl')
 
 def make_comparison_sheet(flat_statements, comp_statements):
+    """Makes a tsv sheet to diff flat and compositional groundings."""
     header = ["Entity Text", "Grounding", "Confidence"]
     with open('wm_comparison_sheet.tsv', 'wt') as out_file:
         tsv_writer = csv.writer(out_file, delimiter='\t')
         tsv_writer.writerow(header)
         for statement in flat_statements[:500]:
             # get text/groundings for flat subject/object
-            flat_subj_text = get_entity_text(statement.subj)
+            flat_subj_text = get_text(statement.subj)
             flat_subj_grounding = get_groundings(statement.subj)[0]
-            flat_obj_text = get_entity_text(statement.obj)
+            flat_obj_text = get_text(statement.obj)
             flat_obj_grounding = get_groundings(statement.obj)[0]
-            for statement in comp_statements[:500]:
+            for statement2 in comp_statements[:500]:
                 # get text/groundings for compositional subject/object
                 # TODO: get into compositional tuples!
-                comp_subj_text = get_entity_text(statement.subj)
-                (comp_subj_groundings, comp_subj_scores) = get_compositional_groundings(statement.subj)
-                comp_obj_text = get_entity_text(statement.obj)
-                (comp_obj_groundings, comp_obj_scores) = get_compositional_groundings(statement.obj)
+                comp_subj_text = get_text(statement2.subj)
+                (comp_subj_groundings, comp_subj_scores) = (
+                    get_compositional_groundings(statement2.subj))
+                comp_obj_text = get_text(statement2.obj)
+                (comp_obj_groundings, comp_obj_scores) = (
+                    get_compositional_groundings(statement2.obj))
 
-                if (flat_subj_text == comp_subj_text & flat_obj_text == comp_obj_text):
+                if (flat_subj_text == comp_subj_text) & (flat_obj_text == comp_obj_text):
                     flat_subj_line = [flat_subj_text, flat_subj_grounding[0], flat_subj_grounding[1]]
                     comp_subj_line = [comp_subj_text, comp_subj_groundings, comp_subj_scores]
                     flat_obj_line = [flat_obj_text, flat_obj_grounding[0], flat_obj_grounding[1]]
@@ -53,7 +57,7 @@ def obj_from_evidence(evidence) -> str:
     return object_text
 
 
-def get_entity_text(event):
+def get_text(event):
     """Returns the text of the entity (subject or object)."""
     entity_text = event.concept.db_refs["TEXT"]
     return entity_text
@@ -66,12 +70,14 @@ def get_groundings(event):
 
 
 def get_compositional_groundings(event):
-    """Returns a list of (grounding, confidence) tuples from an event."""
+    """Returns a list of (grounding, confidence) tuples from an event.
+
+    TODO: Check this! Since I don't have the compositional statements yet."""
     grounding = event.concept.db_refs["WM"][0]
     terms = []
     scores = []
     for item in grounding:
-        if item != None:
+        if item is not None:
             term = item[0]
             score = item[1]
             terms.append(term)
@@ -79,7 +85,7 @@ def get_compositional_groundings(event):
     return (terms, scores)
 
 
-def get_CAG_nodes(statements):
+def get_cag_nodes(statements):
     """Returns number of nodes in CAG.
 
     Loops through list of statements, counts unique subject/object nodes. Does
@@ -88,9 +94,9 @@ def get_CAG_nodes(statements):
     the same Event but be unequal.
     """
     nodes = []
-    for statement in statements:
-        subj = statement.subj.concept.db_refs["TEXT"]
-        obj = statement.obj.concept.db_refs["TEXT"]
+    for statement in tqdm(statements):
+        subj = get_text(statement.subj)
+        obj = get_text(statement.obj)
         if subj not in nodes:
             nodes.append(subj)
         if obj not in nodes:
@@ -105,15 +111,78 @@ def get_self_loops(statements):
     Finds nodes where the subject and object top GROUNDING is the same.
     """
     self_loops = []
-    for statement in statements:
+    for statement in tqdm(statements):
         subj = statement.subj.concept.db_refs["WM"][0]
         obj = statement.obj.concept.db_refs["WM"][0]
         if subj == obj:
             self_loops.append(statement)
     print(f"{len(self_loops)} self-loops out of {len(statements)} statements.")
+    return self_loops
 
 
+def get_contradictions(statements):
+    """Gets the list/number of contradictions in the CAG.
 
-get_CAG_nodes(stmts_flat)
-get_self_loops(stmts_flat)
-#make_comparison_sheet(stmts_flat)
+    Finds counts instances where the subj -> obj polarity for one node does
+    not match the subj -> obj polarity for another node with the same edges.
+
+    Adds raw statements to list, so even with the same text of subj/obj will
+    probably be considered unique for counting purposes.
+
+    TODO: Change list to include only text of statements, so we can reduce to
+    unique contradictions?
+    """
+    contradictions = []
+    i = 1
+    total_comparisons = 0
+    for statement in tqdm(statements):
+        subject1 = get_text(statement.subj)
+        object1 = get_text(statement.obj)
+        subject_polarity = statement.subj.delta.polarity
+        object_polarity = statement.obj.delta.polarity
+        for j in range(i, len(statements)):
+            subject2 = get_text(statements[j].subj)
+            object2 = get_text(statements[j].obj)
+            # only check for contradictions if the subj/obj match
+            if (subject1 == subject2) and (object1 == object2):
+                total_comparisons += 1
+                subject2_polarity = statements[j].subj.delta.polarity
+                object2_polarity = statements[j].obj.delta.polarity
+                # check if their subj/obj polarities are equal
+                subjects_equal = subject_polarity == subject2_polarity
+                objects_equal = object_polarity == object2_polarity
+                # if the polarity of the subjects are equal but not the
+                # objects, or if the polarity of the objects are equal but
+                # not the subjects, then we have a contradiction
+                if (subjects_equal) and (not objects_equal):
+                    contradiction = (statement, statements[j])
+                    contradictions.append(contradiction)
+                elif (not subjects_equal) and (objects_equal):
+                #if not subjects_equal and objects_equal:
+                    contradiction = (statement, statements[j])
+                    contradictions.append(contradiction)
+                # else condition is when polarities both match OR when both
+                # polarities are the opposite
+                # TODO: double check that this logic makes sense..
+                else:
+                    continue
+        i += 1
+
+    print(f"{len(contradictions):,} contradictions out of "
+          f"{total_comparisons:,} comparisons "
+          f"({(len(contradictions)/total_comparisons)*100} %).")
+    return contradictions
+
+
+def get_basic_stats(statements):
+    """Returns a bunch of basic states from a list of statements."""
+    print("Getting unique nodes in the CAG...")
+    get_cag_nodes(statements)
+    print("Getting self-loops in the CAG...")
+    get_self_loops(statements)
+    print("Getting contradictions in the CAG...")
+    get_contradictions(statements)
+
+
+get_basic_stats(STMTS_FLAT)
+#make_comparison_sheet(STMTS_FLAT)


### PR DESCRIPTION
Various functions to get stats from INDRA statements as well as to compare flat and compositional grounding.
The functions added do the following:
- Make diff/comparison sheet for flat/compositional grounding
- Get the number of nodes in the CAG
- Get the number of self-looping nodes in the CAG (nodes with the same subj/obj top grounding)
- Get the number of contradictions in the CAG (nodes which have the same subjects and objects but differing polarity)
- Some helper functions to get the raw text of subject/object from the evidence, get groundings, get the text of the CAG edge

Also includes INDRA statements using the flat ontology.